### PR TITLE
Fix Json serialization for OperationStatus.InProgress

### DIFF
--- a/src/YandexDisk.Client.Tests/YandexDisk.Client.Tests.csproj
+++ b/src/YandexDisk.Client.Tests/YandexDisk.Client.Tests.csproj
@@ -58,6 +58,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/YandexDisk.Client.Tests/app.config
+++ b/src/YandexDisk.Client.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/YandexDisk.Client/Protocol/Operation.cs
+++ b/src/YandexDisk.Client/Protocol/Operation.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace YandexDisk.Client.Protocol
 {
@@ -17,6 +19,7 @@ namespace YandexDisk.Client.Protocol
     /// <summary>
     /// Возможные статусы опреаций
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OperationStatus
     {
         /// <summary>

--- a/src/YandexDisk.Client/Protocol/Operation.cs
+++ b/src/YandexDisk.Client/Protocol/Operation.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
 
 namespace YandexDisk.Client.Protocol
 {
     /// <summary>
-    /// Статус операции. Операции запускаются, когда вы копируете, перемещаете или удаляете непустые папки. 
+    /// Статус операции. Операции запускаются, когда вы копируете, перемещаете или удаляете непустые папки.
     /// URL для запроса статуса возвращается в ответ на такие запросы.
     /// </summary>
     public class Operation : ProtocolObjectResponse
@@ -32,7 +32,7 @@ namespace YandexDisk.Client.Protocol
         /// <summary>
         /// Операция начата, но еще не завершена.
         /// </summary>
-        [JsonProperty("in-progress")]
-        InProgress,
+        [EnumMember(Value = "in-progress")]
+        InProgress
     }
 }

--- a/src/YandexDisk.Client/YandexDisk.Client.csproj
+++ b/src/YandexDisk.Client/YandexDisk.Client.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -49,6 +49,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -99,7 +100,10 @@
     <Compile Include="Protocol\Link.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/YandexDisk.Client/app.config
+++ b/src/YandexDisk.Client/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/YandexDisk.Client/packages.config
+++ b/src/YandexDisk.Client/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
The present annotation of `OperationStatus.InProgress` with a `JsonPropertyAttribute("in_progress")` is ineffective and results in a Json serialization to the string value of "InProgress".
This needs to be changed to an `EnumMemberAttribute(Value = "in-progress")` to get the correct Json serialization format of "in-progress".

If you look into the code of `Newtonsoft.Json.Utilities.EnumUtils` you'll find that the `InitializeEnumType(...)` method respects `System.Runtime.Serialization.EnumMemberAttribute` but not `Newtonsoft.Json.JsonPropertyAttribute`.

Please update your package in due course - it appears to work quite well otherwise.

Also: Please update the NuGet reference to Newtonsoft.Json to version 8.0.2 or greater.

Regards
viciousviper