### PR TITLE
Added yadisk.exe.config to nuget package

### DIFF
--- a/src/YandexDisk.Client.CLI.nuspec
+++ b/src/YandexDisk.Client.CLI.nuspec
@@ -28,6 +28,7 @@ Copyright (c) 2015-2017 Yuriy Nagaev</summary>
         <file src="YandexDisk.Client.CLI\bin\Release\Newtonsoft.Json.dll" target="tools\net46\Newtonsoft.Json.dll" />
         <file src="YandexDisk.Client.CLI\bin\Release\System.Net.Http.Formatting.dll" target="tools\net46\System.Net.Http.Formatting.dll" />
         <file src="YandexDisk.Client.CLI\bin\Release\yadisk.exe" target="tools\net46\yadisk.exe" />
+        <file src="YandexDisk.Client.CLI\bin\Release\yadisk.exe.config" target="tools\net46\yadisk.exe.config" />
         <file src="YandexDisk.Client.CLI\bin\Release\YandexDisk.Client.dll" target="tools\net46\YandexDisk.Client.dll" />
     </files>
 </package>

--- a/src/YandexDisk.Client.sln
+++ b/src/YandexDisk.Client.sln
@@ -9,6 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YandexDisk.Client.Tests.Net
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{347D39BC-5D1C-41BE-8D19-B93E520359FD}"
 	ProjectSection(SolutionItems) = preProject
+		YandexDisk.Client.CLI.nuspec = YandexDisk.Client.CLI.nuspec
 		YandexDisk.Client.nuspec = YandexDisk.Client.nuspec
 	EndProjectSection
 EndProject


### PR DESCRIPTION
I had an issue when I tried to run CLI tool:
Could not load file or assembly 'Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)

Added Yandex.Client.CLI.nuspec to solution.
Added yadisk.exe.config to nuget package to solve assembly redirection issues (Newtonsoft.Json)